### PR TITLE
Anpassung an PHWT-Vorgaben und Optimierung von Zitaten

### DIFF
--- a/AusarbeitungStart.tex
+++ b/AusarbeitungStart.tex
@@ -37,11 +37,14 @@
 % ------------------------------------------------------------------------------
 \input{../../Packages}
 
-% Erstellung eines Abkürzungsverzeichnisses aktivieren ---------------
+% Erstellung eines Abkürzungsverzeichnisses aktivieren -------------------------
 \makenomenclature
 
 % Kopf- und Fußzeilen, Seitenränder etc. ---------------------------------------
 \input{../../Seitenstil}
+
+% Individuelle Zitierweise in jeder Ausarbeitung -------------------------------
+\input{Zitierweise}
 
 % eigene LaTeX-Befehle, verwendbar in allen Referaten
 \input{../../Befehle}

--- a/Ausarbeitungen/.gitignore
+++ b/Ausarbeitungen/.gitignore
@@ -1,1 +1,0 @@
-/Vorlage/

--- a/Ausarbeitungen/Vorlage/Inhalt/Einleitung.tex
+++ b/Ausarbeitungen/Vorlage/Inhalt/Einleitung.tex
@@ -1,7 +1,7 @@
 \section{Einleitung}
 \label{sec:Einleitung}
 
-Ein Zitat zum Erstellen der Bibliographie: \cite{Martin2008}. 
+Ein Zitat zum Erstellen der Bibliographie: \Zitati[S.~35]{Martin2008}.
 Es werden nur die verwendeten Quellen im Literaturverzeichnis aufgeführt, sodass
 eine zentrale Datei für alle Ausarbeitungen genutzt werden.
 

--- a/Ausarbeitungen/Vorlage/Zitierweise.tex
+++ b/Ausarbeitungen/Vorlage/Zitierweise.tex
@@ -1,0 +1,13 @@
+% zum Wechseln vom Chicago in den Harvard-Style müssen die Zeilen des Chicago-Styles deaktiviert und
+%  die des Harvard-Styles aktiviert werden. Die gilt nur für diese Ausarbeitung.
+
+% (z.B. \Zitati[S.~69]{Martin2008a})
+
+% Zitate
+\newcommand{\Zitati}[2][\empty]{\footnote{\Vgl \allgemeinesZitat[#1]{#2}.}} % indirektes Zitat im Chicago-Style
+\newcommand{\Zitatd}[2][\empty]{\footnote{\allgemeinesZitat[#1]{#2}.}} % direktes Zitat im Chicago-Style
+
+%\newcommand{\Zitati}[2][\empty]{ (\vgl \allgemeinesZitat[#1]{#2})} % indirektes Zitat im Harvard-Style
+%\newcommand{\Zitatd}[2][\empty]{ (\allgemeinesZitat[#1]{#2})} % direktes Zitat im Harvard-Style
+% nur für intern, sollte nicht in Ausarbeitungen genutzt werden:
+\newcommand{\allgemeinesZitat}[2][\empty]{\ifthenelse{\equal{#1}{\empty}}{\citep{#2}}{\citep[#1]{#2}}}

--- a/Befehle.tex
+++ b/Befehle.tex
@@ -1,0 +1,29 @@
+% Abkürzungen, ggf. mit korrektem Leerraum
+\newcommand{\bs}{$\backslash$\xspace}
+\newcommand{\bspw}{bspw.\xspace}
+\newcommand{\bzw}{bzw.\xspace}
+\newcommand{\ca}{ca.\xspace}
+\newcommand{\dahe}{\mbox{d.\,h.}\xspace}
+\newcommand{\etc}{etc.\xspace}
+\newcommand{\eur}[1]{\mbox{#1\,\texteuro}\xspace}
+\newcommand{\evtl}{evtl.\xspace}
+\newcommand{\ggf}{ggf.\xspace}
+\newcommand{\Ggf}{Ggf.\xspace}
+\newcommand{\gqq}[1]{\glqq{}#1\grqq{}}
+\newcommand{\inkl}{inkl.\xspace}
+\newcommand{\insb}{insb.\xspace}
+\newcommand{\ua}{\mbox{u.\,a.}\xspace}
+\newcommand{\usw}{usw.\xspace}
+\newcommand{\Vgl}{Vgl.~}
+\newcommand{\vgl}{vgl.~}
+\newcommand{\zB}{\mbox{z.\,B.}\xspace}
+
+% Befehle für häufig anfallende Aufgaben
+\newcommand{\Abbildung}[1]{\autoref{fig:#1}}
+\newcommand{\Anhang}[1]{\appendixname{}~\ref{#1}: \nameref{#1} \vpageref{#1}} % Referenzierung eines Anhangs
+\newcommand{\includegraphicsKeepAspectRatio}[2]{\includegraphics[width=#2\textwidth,height=#2\textheight,keepaspectratio]{#1}} % Einfügen einer Graphik und Seitenverhältnis beibehalten
+\newcommand{\includegraphicsRotateAndKeepAspectRatio}[2]{\includegraphics[width=#2\textheight,height=#2\textwidth,keepaspectratio,angle=90,origin=c]{#1}} % Einfügen einer entgegen dem Uhrzeigersinn gedrehten Graphik und Seitenverhältnis beibehalten
+\newcommand{\itemd}[2]{\item{\bf{#1}}\\{#2}} % erzeugt ein Listenelement mit fetter Überschrift
+\newcommand{\Kapitel}[1]{Kapitel~\ref{sec:#1}~(\nameref{sec:#1})} % Referenzierung eines Kapitels
+\newcommand{\Abschnitt}[1]{Abschnitt~\ref{subsec:#1}~(\nameref{subsec:#1})} % Referenzierung eines Abschnitts
+\newcommand{\Unterabschnitt}[1]{Unterabschnitt~\ref{subsubsec:#1}~(\nameref{subsubsec:#1})} % Referenzierung eines Unterabschnitts

--- a/Bibliographie.bib
+++ b/Bibliographie.bib
@@ -26,3 +26,13 @@
   totalpages = {624},
   url = {http://amazon.com/o/ASIN/1593271190/}
 }
+
+@BOOKLET{Beck2001,
+  title = {Manifesto for Agile Software Development},
+  author = {Kent Beck and Mike Beedle and Arie van Bennekum and Alistair Cockburn and Ward Cunningham and Martin Fowler
+            and James Grenning and Jim Highsmith and Andrew Hunt and Ron Jeffries and Jon Kern and Brian Marick and
+            Robert C. Martin and Steve Mellor and Ken Schwaber and Jeff Sutherland and Dave Thomas},
+  url = {https://agilemanifesto.org/},
+  year = {2001},
+  lastchecked = {01.01.2022}
+}

--- a/Seitenstil.tex
+++ b/Seitenstil.tex
@@ -1,6 +1,6 @@
 % Seitenränder -----------------------------------------------------------------
 \setlength{\topskip}{\ht\strutbox} % behebt Warnung von geometry
-\geometry{a4paper,left=25mm,right=20mm,top=25mm,bottom=25mm,includefoot,footskip=15mm}
+\geometry{a4paper,left=40mm,right=25mm,top=25mm,bottom=20mm,includefoot,footskip=15mm}
 
 \usepackage[
 	automark, % Kapitelangaben in Kopfzeile automatisch erstellen
@@ -24,6 +24,7 @@
 \cfoot{}
 \ofoot{\pagemark}
 
+\spacing{1.3} % Zeilenabstand 1,3
 \frenchspacing % erzeugt ein wenig mehr Platz hinter einem Punkt
 
 % Schusterjungen und Hurenkinder vermeiden

--- a/natdin.bst
+++ b/natdin.bst
@@ -178,14 +178,14 @@ ENTRY
 
 %  Abkuerzung ("... und andere") bei Mehrverfasserquellen:
 
-FUNCTION { ua.etal } { " u.\,a." }  %% evtl. auch in eckigen Klammern  " [u.\,a.]"
+FUNCTION { ua.etal } { " et~al." }
 
-%%  oder lateinisch:  FUNCTION { ua.etal } { " et~al." }
+%%  oder deutsch:  FUNCTION { ua.etal } { " u.\,a." }  %% evtl. auch in eckigen Klammern  " [u.\,a.]"
 
 
 FUNCTION { und } { " und " }
 
-%%  oder ausgeschrieben:  FUNCTION { und } { " und " }
+%%  oder ausgeschrieben:  FUNCTION { und } { " / " }
 
 
 % Einige elektronische Medien erhalten nach DIN 1505 eine "Ergaenzende Angabe"

--- a/natdin.bst
+++ b/natdin.bst
@@ -182,6 +182,7 @@ FUNCTION { ua.etal } { " u.\,a." }  %% evtl. auch in eckigen Klammern  " [u.\,a.
 
 %%  oder lateinisch:  FUNCTION { ua.etal } { " et~al." }
 
+
 FUNCTION { und } { " und " }
 
 %%  oder ausgeschrieben:  FUNCTION { und } { " und " }
@@ -427,7 +428,7 @@ FUNCTION {format.online.lastcheck}
              cite$ * warning$
           }
           { part.of.sentence
-            lastchecked "Abruf: " swap$ * output
+            lastchecked "Abruf:~" swap$ * output
           }
         if$
       }


### PR DESCRIPTION
Der Seitenrand wurde an die aktuellen Vorgaben der PHWT angepasst.
In der Bibliographie wird jetzt eine Vorlage zur idiomatischen Angabe einer Internetquelle angegeben.
Die Zitierweise (Chicago oder Harvard) kann jetzt für jede Ausarbeitung individuell festgelegt werden und im gesamten Projekt kann einheitlich mit z.B. "\Zitati[S.~35]{Martin2008}" für ein indirektes und analog dazu mit dem Befehl "\Zitatd" indirekt zitiert werden.
Mehrere Autoren werden jetzt mit "/" (ansatt "und") bzw. "et. al" (ansatt "u. a.") angegeben.
Es wurden eine Menge Befehle gemäß der [LaTeX-Vorlage zur Projektdokumentation für Fachinformatiker Anwendungsentwicklung](https://github.com/StefanMacke/latex-vorlage-fiae/blob/master/Allgemein/Befehle.tex) übernommen, dabei wurde u.a. der Befehl "\includegraphicsRotateAndKeepAspectRatio" ergänzt und "\Ggfs" bzw. "\ggfs" zu der gängigeren Variante "\Ggf" bzw. "\ggf" geändert (und die Ausgabe entsprechend angepasst).